### PR TITLE
Medium typo fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2.210 — Unreleased
+
+## Fixed
+
+* `Medium` naming.
+
 ## [2.200] — April 13, 2023
 
 ## Fixed

--- a/Lilex.glyphs
+++ b/Lilex.glyphs
@@ -126341,7 +126341,7 @@ instanceInterpolations = {
 "055264FC-C366-4C37-95B8-CB5161C9C36E" = 0.33333;
 "A5F3D33E-00A1-4213-AAE8-48E0A2B2F36F" = 0.66667;
 };
-name = Meduim;
+name = Medium;
 weightClass = 500;
 },
 {

--- a/Lilex.glyphs
+++ b/Lilex.glyphs
@@ -126526,5 +126526,5 @@ tH = 19;
 };
 };
 versionMajor = 2;
-versionMinor = 200;
+versionMinor = 210;
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ arrrgs==2.0.0
 ruff==0.0.259
 pylint==2.17.1
 colored==1.4.4
-fontbakery[freetype]==0.8.11
+fontbakery[freetype]==0.8.13


### PR DESCRIPTION
`Meduim` → `Medium`

Fixes #12 