### PR TITLE
fix: improve JSDoc alignments (slash asterisk)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,25 +5,29 @@ All notable changes to this project will be documented in this file.
 
 ## Added
 
-* `ss04` for broken number signs (`####`)
+* `ss04` for broken number signs. (`####`) [#28](https://github.com/mishamyrt/Lilex/pull/28)
+
+## Fixed
+
+* Aligning slash asterisk sequences. (`/*`, `*/`) [#29](https://github.com/mishamyrt/Lilex/pull/29)
 
 ## [2.300] — November 7, 2023
 
 ## Added
 
-* `cv11` for connected bar with less or greater (`<|`, `|>`)
+* `cv11` for connected bar with less or greater. (`<|`, `|>`)
 
 ## Fixed
 
 * `Medium` naming.
-* Vertical align for some arrow parts (`greater_greater_equal_end.seq`, `greater_greater_equal_middle.seq`)
+* Vertical align for some arrow parts. (`greater_greater_equal_end.seq`, `greater_greater_equal_middle.seq`)
 
 ## [2.200] — April 13, 2023
 
 ## Fixed
 
 * Long `----` and `====` are no longer breaking in iTerm2.
-* Metrics (`underlineThickness`, `hhea`, `usWinAscent`, `usWinDescent`, `panose`).
+* Metrics. (`underlineThickness`, `hhea`, `usWinAscent`, `usWinDescent`, `panose`)
 * Width of some glyphs.
 * `fsSelection` and `macStyle`.
 * Arrows with `ss01`.
@@ -40,7 +44,7 @@ All notable changes to this project will be documented in this file.
 * `<>`, `|>`, `<|`, `<+>`, `||>`, `<||`, `|||`.
 * `<$`, `$>`, `<$>`.
 * Generated bar-underscores `_|_|_`.
-* Powerline support (`uniE0A0`, `uniE0A2`, `uniE0B0`, `uniE0B1`, `uniE0B2`, `uniE0B3`).
+* Powerline support. (`uniE0A0`, `uniE0A2`, `uniE0B0`, `uniE0B1`, `uniE0B2`, `uniE0B3`)
 * ExtraThick weight (Read [commit](https://github.com/mishamyrt/Lilex/commit/fe983370a278eca78a27434f2ddbf75e8505e8ed) message).
 * Fontbakery reports to bundle.
 * `ss02` for gap in equals (`==`, `!=`, `===`, `!==`).

--- a/Lilex.glyphs
+++ b/Lilex.glyphs
@@ -1614,6 +1614,7 @@ stemValues = (
 24,
 58
 );
+visible = 1;
 },
 {
 axesValues = (
@@ -63458,7 +63459,7 @@ width = 600;
 },
 {
 glyphname = asterisk_slash.liga;
-lastChange = "2023-03-24 20:17:54 +0000";
+lastChange = "2023-11-23 20:07:27 +0000";
 layers = (
 {
 guides = (
@@ -63470,11 +63471,11 @@ pos = (-600,636);
 layerId = "A5F3D33E-00A1-4213-AAE8-48E0A2B2F36F";
 shapes = (
 {
-pos = (-35,0);
+pos = (-85,0);
 ref = slash;
 },
 {
-pos = (-511,0);
+pos = (-600,0);
 ref = asterisk;
 }
 );
@@ -63484,11 +63485,11 @@ width = 600;
 layerId = "C7B35BE3-AA13-4B78-992E-F05F1268D666";
 shapes = (
 {
-pos = (-35,0);
+pos = (-86,0);
 ref = slash;
 },
 {
-pos = (-511,0);
+pos = (-600,0);
 ref = asterisk;
 }
 );
@@ -63498,11 +63499,11 @@ width = 600;
 layerId = "055264FC-C366-4C37-95B8-CB5161C9C36E";
 shapes = (
 {
-pos = (-35,0);
+pos = (-78,0);
 ref = slash;
 },
 {
-pos = (-511,0);
+pos = (-600,0);
 ref = asterisk;
 }
 );
@@ -64790,7 +64791,7 @@ width = 600;
 },
 {
 glyphname = slash_asterisk.liga;
-lastChange = "2023-03-24 20:17:08 +0000";
+lastChange = "2023-11-23 20:13:29 +0000";
 layers = (
 {
 guides = (
@@ -64810,11 +64811,10 @@ pos = (279,-243);
 layerId = "A5F3D33E-00A1-4213-AAE8-48E0A2B2F36F";
 shapes = (
 {
-pos = (-546,0);
+pos = (-521,0);
 ref = slash;
 },
 {
-pos = (-86,0);
 ref = asterisk;
 }
 );
@@ -64824,11 +64824,10 @@ width = 600;
 layerId = "C7B35BE3-AA13-4B78-992E-F05F1268D666";
 shapes = (
 {
-pos = (-546,0);
+pos = (-522,0);
 ref = slash;
 },
 {
-pos = (-86,0);
 ref = asterisk;
 }
 );
@@ -64838,11 +64837,10 @@ width = 600;
 layerId = "055264FC-C366-4C37-95B8-CB5161C9C36E";
 shapes = (
 {
-pos = (-546,0);
+pos = (-515,0);
 ref = slash;
 },
 {
-pos = (-86,0);
 ref = asterisk;
 }
 );


### PR DESCRIPTION
The JSDoc appears to be slightly skewed. This PR fixes the alignment and lines up the asterisks in an even line.


### Before
<img width="500" alt="image" src="https://github.com/mishamyrt/Lilex/assets/19162401/a762cabe-8052-4f1f-957d-878b35ea7bb2">

### After
<img width="500" alt="image" src="https://github.com/mishamyrt/Lilex/assets/19162401/1e16b3b8-7cec-452c-8f6e-3603232835c5">
