### PR TITLE
chore: update gftools and fontbakery

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 fontmake==3.7.1
 cu2qu==1.6.7.post2
-gftools==0.9.41
+gftools==0.9.51
 glyphsLib==6.6.0
 arrrgs==3.1.0
 ruff==0.1.8
 pylint==3.0.3
 colored==2.2.3
 pylance==0.8.17
-fontbakery[freetype]==0.10.8
+fontbakery[freetype]==0.11.2


### PR DESCRIPTION
gftools: 0.9.41 -> 0.9.51
fontbakery: 0.10.8 -> 0.11.2

glyphsets updated their API and subsequently rolled their changes out on gftools and fontbakery. Font requires these changes to build. Updated build lgtm, but I'm not an expert so please double check.

Maybe we could have `2.400.1` to fix this sooner? My cache can't build the font atm.